### PR TITLE
Fixed "roles" name error in  Localization files

### DIFF
--- a/src/Aguacongas.TheIdServer.Duende/Localization-de.json
+++ b/src/Aguacongas.TheIdServer.Duende/Localization-de.json
@@ -1148,7 +1148,7 @@
 	"value": "Rolle"
   },
   {
-	"key": "roles",
+	"key": "Roles",
 	"value": "Rollen"
   },
   {

--- a/src/Aguacongas.TheIdServer.Duende/Localization-fr.json
+++ b/src/Aguacongas.TheIdServer.Duende/Localization-fr.json
@@ -1148,8 +1148,8 @@
     "value": "rôle"
   },
   {
-    "key": "roles",
-    "value": "rôles"
+    "key": "Roles",
+    "value": "Rôles"
   },
   {
     "key": "Save",

--- a/src/Aguacongas.TheIdServer.Duende/Localization-zh.json
+++ b/src/Aguacongas.TheIdServer.Duende/Localization-zh.json
@@ -1148,7 +1148,7 @@
 		"value": "角色"
 	},
 	{
-		"key": "roles",
+		"key": "Roles",
 		"value": "角色"
 	},
 	{


### PR DESCRIPTION
The entry named "roles" in the localization file should be "Roles" (with a capital R), otherwise it will cause a translation to be ineffective.