### PR TITLE
Security: update nginx base image to patched version

### DIFF
--- a/src/Aguacongas.TheIdServer.BlazorApp/Dockerfile
+++ b/src/Aguacongas.TheIdServer.BlazorApp/Dockerfile
@@ -41,7 +41,7 @@ FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./Aguacongas.TheIdServer.BlazorApp.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish /p:UseAppHost=false -p:FileVersion="$FILE_VERSION" -p:SourceRevisionId="$SOURCE_VERSION"
 
-FROM nginx:1.29.3-alpine3.22-slim AS final
+FROM nginx:alpine3.24-slim AS final
 WORKDIR /usr/share/nginx/html
 COPY --from=publish /app/publish/wwwroot .
 COPY --from=build /src/src/Aguacongas.TheIdServer.BlazorApp/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
## Contexte
L'image \guacongas/theidserverapp\ est construite sur \
ginx:1.29.3-alpine3.22-slim\, une base vulnérable.

## Vulnérabilités corrigées
- **CVE-2026-42533** (critical, CVSS 8.1) : heap buffer overflow dans ngx_http_regex_map - exécution de code à distance
- **CVE-2026-48142** : heap buffer over-read dans ngx_http_charset_module - divulgation mémoire
- **CVE-2026-1642** : injection SSL upstream
- **CVE-2026-42926** : injection HTTP/2 dans le proxy
- **CVE-2026-9256** : buffer overflow dans ngx_http_rewrite_module
- Alpine 3.22 : **CVE-2026-45447** (use-after-free OpenSSL -> RCE), **CVE-2026-34182** (contournement intégrité CMS), **CVE-2026-55200** (libssh2 out-of-bounds write -> RCE)

## Correctif
\
ginx:1.29.3-alpine3.22-slim\ -> \
ginx:alpine3.24-slim\
- nginx **1.31.5** (>= 1.31.3, fixé) sur Alpine **3.24**
- Tag mutable : les futurs patchs de sécurité seront pris en compte au prochain rebuild